### PR TITLE
fix missing =back in POD

### DIFF
--- a/lib/Collision/2D/Collision.pm
+++ b/lib/Collision/2D/Collision.pm
@@ -148,3 +148,4 @@ my $other_collision = $self->invert();
 This returns the inverse of this collision. That is, the time remains,
 but ent1 and ent2 are swapped, and the axis is inversed. This does not effect $self.
 
+=back


### PR DESCRIPTION

In Debian we are currently applying the following patch to
Collision-2D.
We thought you might be interested in it too.

    Description: fix missing =back in POD
    Origin: vendor
    Author: mason james <mtj@kohaaloha.com>
    Last-Update: 2023-04-23

The patch is tracked in our Git repository at
https://salsa.debian.org/perl-team/modules/packages/libcollision-2d-perl/raw/master/./debian/patches/fix-pod.patch

Thanks for considering,
  Mason James,
  Debian Perl Group
